### PR TITLE
Fix undefined names in Python code

### DIFF
--- a/api.py
+++ b/api.py
@@ -34,7 +34,7 @@ class WikibaseRestAPI:
                       headers=headers, data=data)
 
         if request.status_code != 200:
-            raise ResponseError
+            raise requests.adapters.ResponseError
 
         try:
             return request.json()
@@ -51,10 +51,10 @@ class WikibaseRestAPI:
     def _put(self, content, data):
         return self._request("PUT", content, data=data)
 
-    def _patch(self, content):
+    def _patch(self, content, data):
         return self._request("PATCH", content, data=data)
 
-    def _delete(self, content):
+    def _delete(self, content, data):
         return self._request("DELETE", content, data=data)
 
     # GET


### PR DESCRIPTION
% `ruff --select=E9,F63,F7,F82 --target-version=py37 .`
```
Error: api.py:37:19: F821 Undefined name `ResponseError`
Error: api.py:55:53: F821 Undefined name `data`
Error: api.py:58:54: F821 Undefined name `data`
```
% `ruff rule F821`
# undefined-name (F821)

Derived from the **Pyflakes** linter.

Message formats:
* Undefined name `{name}`
---
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.
---
https://requests.readthedocs.io/en/latest/search/?q=ResponseError
% `python3`
```
>>> import requests
>>> ResponseError
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'ResponseError' is not defined. Did you mean: 'ReferenceError'?
>>> requests.adapters.ResponseError
<class 'urllib3.exceptions.ResponseError'>
```