### PR TITLE
api.py: Fix undefined name payload

### DIFF
--- a/api.py
+++ b/api.py
@@ -87,7 +87,7 @@ class WikibaseRestAPI:
     def _patch(self, path, payload):
         return self._request("patch", path, payload=payload)
 
-    def _delete(self, path, data):
+    def _delete(self, path, payload):
         return self._request("delete", path, payload=payload)
 
 


### PR DESCRIPTION
% `pipx run ruff --select=E9,F63,F7,F82 .`
```
api.py:91:54: F821 Undefined name `payload`
```
% `pipx run ruff rule F821`
# undefined-name (F821)

Derived from the **Pyflakes** linter.

## What it does
Checks for uses of undefined names.

## Why is this bad?
An undefined name is likely to raise `NameError` at runtime.

## Example
```python
def double():
    return n * 2  # raises `NameError` if `n` is undefined when `double` is called
```

Use instead:
```python
def double(n):
    return n * 2
```

## References
- [Python documentation: Naming and binding](https://docs.python.org/3/reference/executionmodel.html#naming-and-binding)